### PR TITLE
Incremental updates, yay!

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
     "require": {
         "akeneo/pim-community-dev": "^1.7",
         "symfony/symfony": "^2.7",
-        "php-amqplib/rabbitmq-bundle": "^1.12"
+        "php-amqplib/rabbitmq-bundle": "^1.12",
+        "ocramius/proxy-manager": "^1.0",
+        "symfony/proxy-manager-bridge": "^2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/spec/Listener/AssociationTypeSavedListenerSpec.php
+++ b/spec/Listener/AssociationTypeSavedListenerSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\Sylake\AkeneoProducerBundle\Listener;
+
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\ObjectManager;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AssociationTypeInterface;
+use Prophecy\Argument;
+use Sylake\AkeneoProducerBundle\Listener\ItemProjectorInterface;
+
+final class AssociationTypeSavedListenerSpec extends ObjectBehavior
+{
+    function let(ItemProjectorInterface $associationTypeProjector)
+    {
+        $this->beConstructedWith($associationTypeProjector);
+    }
+
+    function it_ignores_items_not_being_an_association_type(
+        ItemProjectorInterface $associationTypeProjector,
+        ObjectManager $objectManager
+    ) {
+        $associationTypeProjector->__invoke(Argument::any())->shouldNotBeCalled();
+
+        $this(new LifecycleEventArgs(new \stdClass(), $objectManager->getWrappedObject()));
+    }
+
+    function it_projects_item_being_an_association_type(
+        ItemProjectorInterface $associationTypeProjector,
+        ObjectManager $objectManager,
+        AssociationTypeInterface $associationType
+    ) {
+        $associationTypeProjector->__invoke($associationType)->shouldBeCalled();
+
+        $this(new LifecycleEventArgs($associationType->getWrappedObject(), $objectManager->getWrappedObject()));
+    }
+}

--- a/spec/Listener/AttributeSavedListenerSpec.php
+++ b/spec/Listener/AttributeSavedListenerSpec.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace spec\Sylake\AkeneoProducerBundle\Listener;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
+use Prophecy\Argument;
+use Sylake\AkeneoProducerBundle\Listener\ItemProjectorInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class AttributeSavedListenerSpec extends ObjectBehavior
+{
+    function let(ItemProjectorInterface $attributeProjector, ItemProjectorInterface $attributeOptionProjector)
+    {
+        $this->beConstructedWith($attributeProjector, $attributeOptionProjector);
+    }
+
+    function it_ignores_items_not_being_a_attribute(
+        ItemProjectorInterface $attributeProjector,
+        ItemProjectorInterface $attributeOptionProjector
+    ) {
+        $attributeProjector->__invoke(Argument::any())->shouldNotBeCalled();
+        $attributeOptionProjector->__invoke(Argument::any())->shouldNotBeCalled();
+
+        $this(new GenericEvent(new \stdClass()));
+    }
+
+    function it_projects_item_being_a_attribute(
+        ItemProjectorInterface $attributeProjector,
+        ItemProjectorInterface $attributeOptionProjector,
+        AttributeInterface $attribute
+    ) {
+        $attribute->getOptions()->willReturn([]);
+
+        $attributeProjector->__invoke($attribute)->shouldBeCalled();
+        $attributeOptionProjector->__invoke(Argument::any())->shouldNotBeCalled();
+
+        $this(new GenericEvent($attribute->getWrappedObject()));
+    }
+
+    function it_projects_item_being_a_attribute_and_its_options(
+        ItemProjectorInterface $attributeProjector,
+        ItemProjectorInterface $attributeOptionProjector,
+        AttributeInterface $attribute,
+        AttributeOptionInterface $attributeOption
+    ) {
+        $attribute->getOptions()->willReturn([$attributeOption]);
+
+        $attributeProjector->__invoke($attribute)->shouldBeCalled();
+        $attributeOptionProjector->__invoke($attributeOption)->shouldBeCalled();
+
+        $this(new GenericEvent($attribute->getWrappedObject()));
+    }
+}

--- a/spec/Listener/CategorySavedListenerSpec.php
+++ b/spec/Listener/CategorySavedListenerSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\Sylake\AkeneoProducerBundle\Listener;
+
+use Akeneo\Component\Classification\Model\CategoryInterface;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\ObjectManager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylake\AkeneoProducerBundle\Listener\ItemProjectorInterface;
+
+final class CategorySavedListenerSpec extends ObjectBehavior
+{
+    function let(ItemProjectorInterface $categoryProjector)
+    {
+        $this->beConstructedWith($categoryProjector);
+    }
+
+    function it_ignores_items_not_being_an_category(
+        ItemProjectorInterface $categoryProjector,
+        ObjectManager $objectManager
+    ) {
+        $categoryProjector->__invoke(Argument::any())->shouldNotBeCalled();
+
+        $this(new LifecycleEventArgs(new \stdClass(), $objectManager->getWrappedObject()));
+    }
+
+    function it_projects_item_being_an_category(
+        ItemProjectorInterface $categoryProjector,
+        ObjectManager $objectManager,
+        CategoryInterface $category
+    ) {
+        $categoryProjector->__invoke($category)->shouldBeCalled();
+
+        $this(new LifecycleEventArgs($category->getWrappedObject(), $objectManager->getWrappedObject()));
+    }
+}

--- a/spec/Listener/ItemProjectorSpec.php
+++ b/spec/Listener/ItemProjectorSpec.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace spec\Sylake\AkeneoProducerBundle\Listener;
+
+use Akeneo\Component\Batch\Item\ItemProcessorInterface;
+use Akeneo\Component\Batch\Item\ItemWriterInterface;
+use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+final class ItemProjectorSpec extends ObjectBehavior
+{
+    function let(ItemProcessorInterface $processor, ItemWriterInterface $writer)
+    {
+        $this->beConstructedWith($processor, $writer);
+    }
+
+    function it_projects_an_item(ItemProcessorInterface $processor, ItemWriterInterface $writer)
+    {
+        $item = new \stdClass();
+        $processedItem = new \stdClass();
+
+        $processor->process($item)->willReturn($processedItem);
+        $writer->write([$processedItem])->shouldBeCalled();
+
+        $this($item);
+    }
+
+    function it_projects_an_item_and_prepares_processor_if_needed(
+        StepExecutionAwareInterface $processor,
+        ItemWriterInterface $writer,
+        DefaultValuesProviderInterface $parametersProvider
+    ) {
+        $item = new \stdClass();
+        $processedItem = new \stdClass();
+
+        $this->beConstructedWith($processor, $writer, $parametersProvider);
+
+        $parametersProvider->getDefaultValues()->willReturn(['foo' => 'bar']);
+
+        $processor->setStepExecution(Argument::that(function (StepExecution $stepExecution) {
+            return $stepExecution->getJobParameters()->all() === ['foo' => 'bar'];
+        }))->shouldBeCalled();;
+
+        $processor->process($item)->willReturn($processedItem);
+        $writer->write([$processedItem])->shouldBeCalled();
+
+        $this($item);
+    }
+}

--- a/spec/Listener/ProductSavedListenerSpec.php
+++ b/spec/Listener/ProductSavedListenerSpec.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace spec\Sylake\AkeneoProducerBundle\Listener;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Prophecy\Argument;
+use Sylake\AkeneoProducerBundle\Listener\ItemProjectorInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class ProductSavedListenerSpec extends ObjectBehavior
+{
+    function let(ItemProjectorInterface $productProjector)
+    {
+        $this->beConstructedWith($productProjector);
+    }
+
+    function it_ignores_items_not_being_a_product(ItemProjectorInterface $productProjector)
+    {
+        $productProjector->__invoke(Argument::any())->shouldNotBeCalled();
+
+        $this(new GenericEvent(new \stdClass()));
+    }
+
+    function it_projects_item_being_a_product(ItemProjectorInterface $productProjector, ProductInterface $product)
+    {
+        $productProjector->__invoke($product)->shouldBeCalled();
+
+        $this(new GenericEvent($product->getWrappedObject()));
+    }
+}

--- a/src/Connector/JobParameters/AkeneoProducer.php
+++ b/src/Connector/JobParameters/AkeneoProducer.php
@@ -6,7 +6,10 @@ use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface;
 use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
 
-final class AkeneoProducer implements ConstraintCollectionProviderInterface, DefaultValuesProviderInterface
+/**
+ * Non-final just to make it lazy-loadable.
+ */
+/* final */ class AkeneoProducer implements ConstraintCollectionProviderInterface, DefaultValuesProviderInterface
 {
     /**
      * @var DefaultValuesProviderInterface

--- a/src/Listener/AssociationTypeSavedListener.php
+++ b/src/Listener/AssociationTypeSavedListener.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Sylake\AkeneoProducerBundle\Listener;
+
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Pim\Component\Catalog\Model\AssociationTypeInterface;
+
+final class AssociationTypeSavedListener
+{
+    /** @var ItemProjectorInterface */
+    private $associationTypeProjector;
+
+    public function __construct(ItemProjectorInterface $associationTypeProjector)
+    {
+        $this->associationTypeProjector = $associationTypeProjector;
+    }
+
+    public function postPersist(LifecycleEventArgs $event)
+    {
+        $this($event);
+    }
+
+    public function postUpdate(LifecycleEventArgs $event)
+    {
+        $this($event);
+    }
+
+    public function __invoke(LifecycleEventArgs $event)
+    {
+        $associationType = $event->getObject();
+
+        if (!$associationType instanceof AssociationTypeInterface) {
+            return;
+        }
+
+        $this->associationTypeProjector->__invoke($associationType);
+    }
+}

--- a/src/Listener/AttributeSavedListener.php
+++ b/src/Listener/AttributeSavedListener.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sylake\AkeneoProducerBundle\Listener;
+
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class AttributeSavedListener
+{
+    /** @var ItemProjectorInterface */
+    private $attributeProjector;
+
+    /** @var ItemProjectorInterface */
+    private $attributeOptionProjector;
+
+    public function __construct(ItemProjectorInterface $attributeProjector, ItemProjectorInterface $attributeOptionProjector)
+    {
+        $this->attributeProjector = $attributeProjector;
+        $this->attributeOptionProjector = $attributeOptionProjector;
+    }
+
+    public function __invoke(GenericEvent $event)
+    {
+        $attribute = $event->getSubject();
+
+        if (!$attribute instanceof AttributeInterface) {
+            return;
+        }
+
+        $this->attributeProjector->__invoke($attribute);
+
+        foreach ($attribute->getOptions() as $attributeOption) {
+            $this->attributeOptionProjector->__invoke($attributeOption);
+        }
+    }
+}

--- a/src/Listener/CategorySavedListener.php
+++ b/src/Listener/CategorySavedListener.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Sylake\AkeneoProducerBundle\Listener;
+
+use Akeneo\Component\Classification\Model\CategoryInterface;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+
+final class CategorySavedListener
+{
+    /** @var ItemProjectorInterface */
+    private $categoryProjector;
+
+    public function __construct(ItemProjectorInterface $categoryProjector)
+    {
+        $this->categoryProjector = $categoryProjector;
+    }
+
+    public function postPersist(LifecycleEventArgs $event)
+    {
+        $this($event);
+    }
+
+    public function postUpdate(LifecycleEventArgs $event)
+    {
+        $this($event);
+    }
+
+    public function __invoke(LifecycleEventArgs $event)
+    {
+        $category = $event->getObject();
+
+        if (!$category instanceof CategoryInterface) {
+            return;
+        }
+
+        $this->categoryProjector->__invoke($category);
+    }
+}

--- a/src/Listener/ItemProjector.php
+++ b/src/Listener/ItemProjector.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Sylake\AkeneoProducerBundle\Listener;
+
+use Akeneo\Component\Batch\Item\ItemProcessorInterface;
+use Akeneo\Component\Batch\Item\ItemWriterInterface;
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+
+final class ItemProjector implements ItemProjectorInterface
+{
+    /** @var ItemProcessorInterface */
+    private $processor;
+
+    /** @var ItemWriterInterface */
+    private $writer;
+
+    /** @var DefaultValuesProviderInterface|null */
+    private $parametersProvider;
+
+    public function __construct(
+        ItemProcessorInterface $processor,
+        ItemWriterInterface $writer,
+        DefaultValuesProviderInterface $valuesProvider = null
+    ) {
+        $this->processor = $processor;
+        $this->writer = $writer;
+        $this->parametersProvider = $valuesProvider;
+    }
+
+    public function __invoke($item)
+    {
+       if ($this->processor instanceof StepExecutionAwareInterface) {
+           $jobExecution = new JobExecution();
+           $jobExecution->setJobParameters(new JobParameters($this->parametersProvider->getDefaultValues()));
+
+           $stepExecution = new StepExecution('42', $jobExecution);
+
+           $this->processor->setStepExecution($stepExecution);
+       }
+
+       $this->writer->write([$this->processor->process(clone $item)]);
+    }
+}

--- a/src/Listener/ItemProjectorInterface.php
+++ b/src/Listener/ItemProjectorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sylake\AkeneoProducerBundle\Listener;
+
+interface ItemProjectorInterface
+{
+    /**
+     * @param object $item
+     *
+     * @return void
+     */
+    public function __invoke($item);
+}

--- a/src/Listener/ProductSavedListener.php
+++ b/src/Listener/ProductSavedListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sylake\AkeneoProducerBundle\Listener;
+
+use Pim\Component\Catalog\Model\ProductInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class ProductSavedListener
+{
+    /** @var ItemProjectorInterface */
+    private $productProjector;
+
+    public function __construct(ItemProjectorInterface $productProjector)
+    {
+        $this->productProjector = $productProjector;
+    }
+
+    public function __invoke(GenericEvent $event)
+    {
+        $product = $event->getSubject();
+
+        if (!$product instanceof ProductInterface) {
+            return;
+        }
+
+        $this->productProjector->__invoke($product);
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -15,7 +15,7 @@
             <tag name="akeneo_batch.job" connector="AkeneoProducerBundle connector" type="%pim_connector.job.export_type%" />
         </service>
 
-        <service id="sylake_akeneo_producer.job_parameters" class="Sylake\AkeneoProducerBundle\Connector\JobParameters\AkeneoProducer">
+        <service id="sylake_akeneo_producer.job_parameters" class="Sylake\AkeneoProducerBundle\Connector\JobParameters\AkeneoProducer" lazy="true">
             <argument type="service" id="pim_connector.job.job_parameters.default_values_provider.product_csv_export" />
             <argument type="service" id="pim_connector.job.job_parameters.constraint_collection_provider.product_csv_export" />
             <argument type="collection">
@@ -100,6 +100,18 @@
         <service id="sylake_akeneo_producer.connector.writer.rabbit_mq.category" class="Sylake\AkeneoProducerBundle\Connector\Writer\RabbitMqProducer">
             <argument type="service" id="old_sound_rabbit_mq.sylake_producer" />
             <argument type="string">akeneo_category_updated</argument>
+        </service>
+
+        <service class="Sylake\AkeneoProducerBundle\Listener\AssociationTypeSavedListener">
+            <argument type="service">
+                <service class="Sylake\AkeneoProducerBundle\Listener\ItemProjector">
+                    <argument type="service" id="pim_connector.processor.normalization.association_type" />
+                    <argument type="service" id="sylake_akeneo_producer.connector.writer.rabbit_mq.association_type" />
+                    <argument type="service" id="sylake_akeneo_producer.job_parameters" />
+                </service>
+            </argument>
+            <tag name="doctrine.event_listener" event="postPersist" method="__invoke" />
+            <tag name="doctrine.event_listener" event="postUpdate" method="__invoke" />
         </service>
 
         <service class="Sylake\AkeneoProducerBundle\Listener\AttributeSavedListener">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -101,5 +101,16 @@
             <argument type="service" id="old_sound_rabbit_mq.sylake_producer" />
             <argument type="string">akeneo_category_updated</argument>
         </service>
+
+        <service class="Sylake\AkeneoProducerBundle\Listener\ProductSavedListener">
+            <argument type="service">
+                <service class="Sylake\AkeneoProducerBundle\Listener\ItemProjector">
+                    <argument type="service" id="pim_connector.processor.normalization.product" />
+                    <argument type="service" id="sylake_akeneo_producer.connector.writer.rabbit_mq.product" />
+                    <argument type="service" id="sylake_akeneo_producer.job_parameters" />
+                </service>
+            </argument>
+            <tag name="kernel.event_listener" event="akeneo.storage.pre_save" method="__invoke" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -132,6 +132,18 @@
             <tag name="kernel.event_listener" event="akeneo.storage.pre_save" method="__invoke" />
         </service>
 
+        <service class="Sylake\AkeneoProducerBundle\Listener\CategorySavedListener">
+            <argument type="service">
+                <service class="Sylake\AkeneoProducerBundle\Listener\ItemProjector">
+                    <argument type="service" id="pim_connector.processor.normalization.category" />
+                    <argument type="service" id="sylake_akeneo_producer.connector.writer.rabbit_mq.category" />
+                    <argument type="service" id="sylake_akeneo_producer.job_parameters" />
+                </service>
+            </argument>
+            <tag name="doctrine.event_listener" event="postPersist" method="__invoke" />
+            <tag name="doctrine.event_listener" event="postUpdate" method="__invoke" />
+        </service>
+
         <service class="Sylake\AkeneoProducerBundle\Listener\ProductSavedListener">
             <argument type="service">
                 <service class="Sylake\AkeneoProducerBundle\Listener\ItemProjector">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -102,6 +102,24 @@
             <argument type="string">akeneo_category_updated</argument>
         </service>
 
+        <service class="Sylake\AkeneoProducerBundle\Listener\AttributeSavedListener">
+            <argument type="service">
+                <service class="Sylake\AkeneoProducerBundle\Listener\ItemProjector">
+                    <argument type="service" id="pim_connector.processor.normalization.attribute" />
+                    <argument type="service" id="sylake_akeneo_producer.connector.writer.rabbit_mq.attribute" />
+                    <argument type="service" id="sylake_akeneo_producer.job_parameters" />
+                </service>
+            </argument>
+            <argument type="service">
+                <service class="Sylake\AkeneoProducerBundle\Listener\ItemProjector">
+                    <argument type="service" id="pim_connector.processor.normalization.attribute_option" />
+                    <argument type="service" id="sylake_akeneo_producer.connector.writer.rabbit_mq.attribute_option" />
+                    <argument type="service" id="sylake_akeneo_producer.job_parameters" />
+                </service>
+            </argument>
+            <tag name="kernel.event_listener" event="akeneo.storage.pre_save" method="__invoke" />
+        </service>
+
         <service class="Sylake\AkeneoProducerBundle\Listener\ProductSavedListener">
             <argument type="service">
                 <service class="Sylake\AkeneoProducerBundle\Listener\ItemProjector">


### PR DESCRIPTION
**Implementation details:**
 - products / attributes (with options) are published if saved using a service called saver from Akeneo
 - categories / association types are published if saved through Doctrine ORM

**Known imperfections:**
 - it does not work perfectly if attributes options are added to an attribute without calling that attribute saver (ex. Akeneo's fixtures) - solved by running an export with initial data
 - though it publishes changes of attributes options for any change made in Akeneo's admin panel, there's currently no logic for updating products using those attributes options

Anyway, it brings much more joy to synchronising Akeneo with Sylius, as you don't need to export ALL the stuff of which 99% has been already synced before.