### PR TITLE
Replace ItemProjector by ItemProjectorInterface in ExportProductCommand

### DIFF
--- a/src/Command/ExportProductCommand.php
+++ b/src/Command/ExportProductCommand.php
@@ -4,7 +4,7 @@ namespace Sylake\AkeneoProducerBundle\Command;
 
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
-use Sylake\AkeneoProducerBundle\Connector\Projector\ItemProjector;
+use Sylake\AkeneoProducerBundle\Connector\Projector\ItemProjectorInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,7 +22,7 @@ final class ExportProductCommand extends Command
      * @param ProductQueryBuilderFactoryInterface $productQueryBuilderFactory
      * @param ItemProjector $itemProjector
      */
-    public function __construct(ProductQueryBuilderFactoryInterface $productQueryBuilderFactory, ItemProjector $itemProjector)
+    public function __construct(ProductQueryBuilderFactoryInterface $productQueryBuilderFactory, ItemProjectorInterface $itemProjector)
     {
         $this->productQueryBuilderFactory = $productQueryBuilderFactory;
         $this->itemProjector = $itemProjector;


### PR DESCRIPTION
Exporting a single SKU produced a FatalThrowableError since ExportProductCommand expects an instance of ItemProjector as the second argument, but an instance of SylakeAkeneoProducerBundleConnectorProjectorCompositeItemProjector_000000003c6ee9c6000000004f5cf8e0528e75d94af1e75a8b719f60d1bc208c was given. 

![screenshot_2017-10-11 um 20 23 47](https://user-images.githubusercontent.com/2094727/31459210-ca4f7c00-aec2-11e7-9d00-44ad90bac1e2.png)

